### PR TITLE
Create a mock homepage and config Bootstrap 5 variable

### DIFF
--- a/beatmap_collections/static/css/index.css
+++ b/beatmap_collections/static/css/index.css
@@ -36,3 +36,7 @@
     /* Bootstrap does not use CS */
     background-color: var(--bs-primary) !important;
 }
+
+.text-primary {
+    color: var(--bs-primary) !important;
+}

--- a/beatmap_collections/templates/beatmap_collections/index.html
+++ b/beatmap_collections/templates/beatmap_collections/index.html
@@ -31,7 +31,7 @@
                     </div>
                     <div class="col">
                       <div class="card-body">
-                          <h2 class="card-title">Beatmap Title</h2>
+                          <h2 class="card-title text-primary">Beatmap Title</h2>
                           <p class="card-content lead">made by Test User</p>
                           <p class="card-text">10 beatmaps</p>
                           <p class="card-text">


### PR DESCRIPTION
I create a mock homepage and config Bootstrap variable that required for other pages

<img width="1406" alt="Screen Shot 2564-10-18 at 20 04 30" src="https://user-images.githubusercontent.com/37771900/137738964-95ace1e7-2102-4ca4-bef7-82568b8aabea.png">

## Notes
- The collection card image is not displayed correctly on the iPad Pro and possibly other tablets viewport.
- The collection page does not display collection from the database yet as the collection model needs to be implemented
- The primary color is directly copied from the Figma mockup.
- There will be no decoration on the card as it has low priority.
- There are only 5 beatmaps that can be displayed. If there is any additional beatmap, the box will overflow.

Edit 1:  Add information about numbers of beatmaps

