### PR TITLE
Change infobox to not render content that is blank

### DIFF
--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
@@ -124,9 +124,9 @@
                         <div class="row">
                             <p></p>
                             <p>
-                                <i class="fas fa-clock"></i> {{ beatmap_entry.beatmap.total_length | length_format }}  <img src="{% static "img/bpm-circle.svg" %}" alt="BPM" height="20px" width="20px"> {{ beatmap_entry.beatmap.bpm }}  <img src="{% static "img/circle-count-circle.svg" %}" alt="Circle count" height="20px" width="20px"> {{ beatmap_entry.beatmap.count_normal }}  <img src="{% static "img/slider-count-circle.svg" %}" alt="Slider count" height="20px" width="20px"> {{ beatmap_entry.beatmap.count_slider }}
+                                <i class="fas fa-clock"></i> {{ beatmap_entry.beatmap.total_length | length_format }}  <img src="{% static "img/bpm-circle.svg" %}" alt="BPM" height="20px" width="20px"> {{ beatmap_entry.beatmap.bpm | thousand_seperator }}  <img src="{% static "img/circle-count-circle.svg" %}" alt="Circle count" height="20px" width="20px"> {{ beatmap_entry.beatmap.count_normal | thousand_seperator }}  <img src="{% static "img/slider-count-circle.svg" %}" alt="Slider count" height="20px" width="20px"> {{ beatmap_entry.beatmap.count_slider | thousand_seperator }}
                                 {% if beatmap_entry.beatmap.mode == 0 or beatmap_entry.beatmap.mode == 1 %}
-                                    <img src="{% static "img/spinner-count-circle.svg" %}" alt="Spinner Count" height="20px" width="20px"> {{ beatmap_entry.beatmap.count_spinner }}
+                                    <img src="{% static "img/spinner-count-circle.svg" %}" alt="Spinner Count" height="20px" width="20px"> {{ beatmap_entry.beatmap.count_spinner | thousand_seperator }}
                                 {% endif %}
                             </p>
                         </div>

--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
@@ -215,8 +215,10 @@
                         </div>
                     </div>
               </div>
+                {% if beatmap_entry.beatmap.source %}
                 <p class="fw-bold">Source</p>
                 <p>{{ beatmap_entry.beatmap.source }}</p>
+                {% endif %}
                 <div class="row">
                     <div class="col-sm-6">
                         <p class="fw-bold">Genre</p>
@@ -289,8 +291,10 @@
                         {% endif %}
                     </div>
                 </div>
+                {% if beatmap_entry.beatmap.tags %}
                 <p class="fw-bold">Tags</p>
                 <p>{{ beatmap_entry.beatmap.tags }}</p>
+                {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Close #67

This issues is from our daily discussion when try to using website.

Some info on infobox can be blank but it's still render so it's weied. That's why I add the condition on template to render only when that field is noit blank.

Before :
![image](https://user-images.githubusercontent.com/68165621/139927018-7f6ad8d0-201d-4ef4-8159-8289c0d56b0d.png)

After:
![image](https://user-images.githubusercontent.com/68165621/139927063-66648305-4430-4c3e-b7ae-a5888cedb197.png)
