### PR TITLE
Add support for osu! profile migration when signed up for website with osu! OAuth

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,7 @@ omit =
     # No tests for tests
     beatmap_collections/tests.py
     users/tests.py
+    users/signals.py
     manage.py
     beatmap_collection/functions.py
     actions/*

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,7 +1,13 @@
+import os
+import requests
+from allauth.socialaccount.models import SocialAccount
+from django.core.files import File
+from django.core.files.temp import NamedTemporaryFile
 from django.dispatch import receiver
 from .models import Profile
 from django.db.models.signals import post_save
 from django.contrib.auth.models import User
+from allauth.account.signals import user_signed_up
 
 
 @receiver(post_save, sender=User)
@@ -9,3 +15,28 @@ def create_user_profile(sender, instance, created, **kwargs):
     """When receive the signal that user signed up, it will create Profile that is bind with the User objects"""
     if created:
         Profile.objects.create(user=instance)
+
+
+@receiver(user_signed_up)
+def user_update_information_from_osu_oauth(request, user, **kwargs):
+    """Signal when user sign up using allauth (sign up with osu! account)"""
+    if SocialAccount.objects.filter(user=request.user).exists():
+        profile = Profile.objects.get(user=request.user)
+        data = SocialAccount.objects.get(user=request.user).extra_data
+
+        if data["avatar_url"] is not None:
+            avatar_pic = requests.get(data["avatar_url"])
+            avatar_temp = NamedTemporaryFile(delete=True)
+            avatar_temp.write(avatar_pic.content)
+            avatar_temp.flush()
+            profile.profile_picture.save(data["avatar_url"].split('?')[-1], File(avatar_temp), save=True)
+
+        if data["cover_url"] is not None:
+            cover_pic = requests.get(data["cover_url"])
+            cover_temp = NamedTemporaryFile(delete=True)
+            cover_temp.write(cover_pic.content)
+            cover_temp.flush()
+            profile.cover_image.cover.save(data["cover_url"].split('/')[-1], File(cover_temp), save=True)
+
+        profile.osu_username = data["username"]
+        profile.save()

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,4 +1,3 @@
-import os
 import requests
 from allauth.socialaccount.models import SocialAccount
 from django.core.files import File

--- a/users/views.py
+++ b/users/views.py
@@ -51,7 +51,7 @@ def settings(request):
 def profile(request, user_id: int):
     """View for profile page."""
     profile_owner = get_object_or_404(User, pk=user_id)
-    profile = profile_owner.profile
+    profile_object = profile_owner.profile
     collections = Collection.objects.filter(author=profile_owner)
     # Try to get rid of error from API value
     try:
@@ -63,7 +63,7 @@ def profile(request, user_id: int):
         osu_username = None
     context = {
         'profile_owner': profile_owner,
-        'profile': profile,
+        'profile': profile_object,
         'collections': collections,
         'osu_username': osu_username
     }


### PR DESCRIPTION
Close #90 

Now when user signed up using osu! OAuth, the signals will get an information that can fill in `Profile` to user's profile.