### PR TITLE
Fix the profile image link on HTTP instead of HTTPS

### DIFF
--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
@@ -112,7 +112,7 @@
                   <div class="col-sm-6">
                       <div class="row">
                           <div class="col-sm-4">
-                              <img src="http://s.ppy.sh/a/{{ beatmap_entry.beatmap.creator_id }}" width="120px" height="120px" alt="{{ beatmap_entry.beatmap.creator }}'s profile" class="rounded-3">
+                              <img src="https://s.ppy.sh/a/{{ beatmap_entry.beatmap.creator_id }}" width="120px" height="120px" alt="{{ beatmap_entry.beatmap.creator }}'s profile" class="rounded-3">
                           </div>
                           <div class="col-sm-8">
                                <p class="beatmap-infobox-date">mapped by <a href="https://osu.ppy.sh/users/{{ beatmap_entry.beatmap.creator_id }}" class="text-decoration-none spacing-hover">{{ beatmap_entry.beatmap.creator }}</a></p>

--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card_demo.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card_demo.html
@@ -115,7 +115,7 @@
                   <div class="col-sm-6">
                       <div class="row">
                           <div class="col-sm-4">
-                              <img src="http://s.ppy.sh/a/{{ beatmap.creator_id }}" width="120px" height="120px" alt="{{ beatmap.creator }}'s profile" class="rounded-3">
+                              <img src="https://s.ppy.sh/a/{{ beatmap.creator_id }}" width="120px" height="120px" alt="{{ beatmap.creator }}'s profile" class="rounded-3">
                           </div>
                           <div class="col-sm-8">
                                <p class="beatmap-infobox-date">mapped by <a href="https://osu.ppy.sh/users/{{ beatmap.creator_id }}" class="text-decoration-none spacing-hover">{{ beatmap.creator }}</a></p>


### PR DESCRIPTION
It's a quick fix regressed from #161 that the link use HTTP instead of HTTPS. (I notice it from Chrome's console but normally the browser will redirect it to HTTPS but I feel bad if I don't fix it)