### PR TITLE
Fix line layout is broken when beatmap source is too long and refactor some inline style to CSS class

### DIFF
--- a/beatmap_collections/static/css/index.css
+++ b/beatmap_collections/static/css/index.css
@@ -270,6 +270,19 @@ a.dropdown-item {
 
 .beatmap-comment {
     line-height: 1.0;
+    margin-top: -5px;
+}
+
+.beatmap-creatpr {
+    margin-top: -5px
+}
+
+.beatmap-author {
+    margin-top: -10px;
+}
+
+.beatmap-button {
+    margin-top: -10px;
 }
 
 .modal-small {

--- a/beatmap_collections/static/css/index.css
+++ b/beatmap_collections/static/css/index.css
@@ -261,11 +261,15 @@ a.dropdown-item {
     font-size: 120%;
 }
 
-.beatmap-artist,
+.beatmap-artist {
+    font-size: 90%;
+    line-height: 0.8;
+}
+
 .beatmap-source {
     font-size: 90%;
     line-height: normal;
-    margin-top: -8px;
+    margin-top: -7px;
 }
 
 .beatmap-comment {

--- a/beatmap_collections/static/css/index.css
+++ b/beatmap_collections/static/css/index.css
@@ -262,7 +262,6 @@ a.dropdown-item {
 }
 
 .beatmap-artist {
-    font-size: 90%;
     line-height: 0.8;
 }
 

--- a/beatmap_collections/static/css/index.css
+++ b/beatmap_collections/static/css/index.css
@@ -264,6 +264,8 @@ a.dropdown-item {
 .beatmap-artist,
 .beatmap-source {
     font-size: 90%;
+    line-height: normal;
+    margin-top: -8px;
 }
 
 .beatmap-comment {

--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
@@ -23,6 +23,7 @@
             {% else %}
             <p>&zwnj;</p>
             {% endif %}
+            <p style="margin-top: -5px">
             {% if beatmap_entry.beatmap.mode == 0 %}
                 <img alt="osu" src="{% static "gamemode/osu.png" %}" width="20px" height="20px">
             {% elif beatmap_entry.beatmap.mode == 1 %}
@@ -35,31 +36,31 @@
 
             {% include "beatmap_collections/snippets/star_rating_color.html" %}
             {% if beatmap_entry.beatmap.approved == "4" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61); margin-top: -2px">LOVED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61);">LOVED</span>
             {% elif beatmap_entry.beatmap.approved == "3" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(106, 196, 254); color: rgb(51, 58, 61); margin-top: -2px">QUALIFIED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(106, 196, 254); color: rgb(51, 58, 61);">QUALIFIED</span>
             {% elif beatmap_entry.beatmap.approved == "2" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(210, 208, 85); color: rgb(51, 58, 61); margin-top: -2px">APPROVED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(210, 208, 85); color: rgb(51, 58, 61);">APPROVED</span>
             {% elif beatmap_entry.beatmap.approved == "1" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(185, 251, 98); color: rgb(51, 58, 61); margin-top: -2px">RANKED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(185, 251, 98); color: rgb(51, 58, 61);">RANKED</span>
             {% elif beatmap_entry.beatmap.approved == "0" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(252, 212, 96); color: rgb(51, 58, 61); margin-top: -2px">PENDING</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(252, 212, 96); color: rgb(51, 58, 61);">PENDING</span>
             {% elif beatmap_entry.beatmap.approved == "-1" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(245, 146, 93); color: rgb(51, 58, 61); margin-top: -2px">WIP</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(245, 146, 93); color: rgb(51, 58, 61);">WIP</span>
             {% elif beatmap_entry.beatmap.approved == "-2" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(0, 0, 0); color: rgb(83, 94, 101); margin-top: -2px">GRAVEYARD</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(0, 0, 0); color: rgb(83, 94, 101);">GRAVEYARD</span>
             {% endif %}
 
             </p>
-              <p class="card-text text-muted" style="margin-top: -5px"><small>mapped by <a href="https://osu.ppy.sh/users/{{ beatmap_entry.beatmap.creator_id }}" class="text-decoration-none spacing-hover-short">{{ beatmap_entry.beatmap.creator }}</a></small></p>
+              <p class="card-text text-muted beatmap-creator"><small>mapped by <a href="https://osu.ppy.sh/users/{{ beatmap_entry.beatmap.creator_id }}" class="text-decoration-none spacing-hover-short">{{ beatmap_entry.beatmap.creator }}</a></small></p>
           {% if beatmap_entry.comment != '' %}
-              <p class="card-text beatmap-comment" style="margin-top: -5px"><small>{{ beatmap_entry.comment }}</small></p>
+              <p class="card-text beatmap-comment"><small>{{ beatmap_entry.comment }}</small></p>
           {% else %}
-            <p class="card-text beatmap-comment" style="margin-top: -5px">&nbsp;</p>
+            <p class="card-text beatmap-comment">&nbsp;</p>
           {% endif %}
-              <p class="card-text text-muted" style="margin-top: -10px"><small>Added by <a href="{% url 'profile' beatmap_entry.author.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap_entry.author.profile.profile_picture.url }}" alt="{{ beatmap_entry.author.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap_entry.author.username }}</a></small></p>
-          <a class="btn btn-beattosetto btn-sm hvr-bounce-to-bottom" href="osu://b/{{ beatmap_entry.beatmap.beatmap_id }}" role="button" style="margin-top: -10px"><i class="fas fa-download color-white"></i> osu!direct</a>
-          <button type="button" class="btn btn-beattosetto btn-sm hvr-bounce-to-bottom" data-bs-toggle="modal" data-bs-target="#modal{{ beatmap_entry.beatmap.beatmap_id }}" style="margin-top: -10px">
+              <p class="card-text text-muted beatmap-author"><small>Added by <a href="{% url 'profile' beatmap_entry.author.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap_entry.author.profile.profile_picture.url }}" alt="{{ beatmap_entry.author.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap_entry.author.username }}</a></small></p>
+          <a class="btn btn-beattosetto btn-sm hvr-bounce-to-bottom beatmap-button" href="osu://b/{{ beatmap_entry.beatmap.beatmap_id }}" role="button"><i class="fas fa-download color-white"></i> osu!direct</a>
+          <button type="button" class="btn btn-beattosetto btn-sm hvr-bounce-to-bottom beatmap-button" data-bs-toggle="modal" data-bs-target="#modal{{ beatmap_entry.beatmap.beatmap_id }}">
               <i class="fas fa-info-circle"></i> Beatmap Detail
             </button>
           </div>

--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card.html
@@ -17,7 +17,7 @@
         <div class="col-md-8 rounded-start" style="line-height: 0.3; background-image: url({{ beatmap_entry.beatmap.beatmap_card.url }}); background-size: cover; background-position: center;">
           <div class="card-body beatmap-card rounded-start rounded-3">
             <a href="{{ beatmap_entry.beatmap.url }}" class="text-decoration-none"><h4 class="card-title spacing-hover-short beatmap-title fw-bold">{{ beatmap_entry.beatmap.title }}</h4></a>
-            <p class="card-text" style="line-height: 0.8">by {{ beatmap_entry.beatmap.artist }}</p>
+            <p class="card-text beatmap-artist">by {{ beatmap_entry.beatmap.artist }}</p>
             {% if beatmap_entry.beatmap.source != "" %}
             <p class="card-text text-muted beatmap-source">{{ beatmap_entry.beatmap.source }}</p>
             {% else %}

--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card_approval.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card_approval.html
@@ -12,12 +12,13 @@
         <div class="col-md-8 rounded-start" style="line-height: 0.3; background-image: url({{ beatmap_entry.beatmap.beatmap_card.url }}); background-size: cover; background-position: center;">
           <div class="card-body beatmap-card rounded-start rounded-3">
             <a href="{{ beatmap_entry.beatmap.url }}" class="text-decoration-none"><h4 class="card-title spacing-hover-short beatmap-title fw-bold">{{ beatmap_entry.beatmap.title }}</h4></a>
-            <p class="card-text" style="line-height: 0.8">by {{ beatmap_entry.beatmap.artist }}</p>
+            <p class="card-text beatmap-artist">by {{ beatmap_entry.beatmap.artist }}</p>
             {% if beatmap_entry.beatmap.source != "" %}
             <p class="card-text text-muted beatmap-source">{{ beatmap_entry.beatmap.source }}</p>
             {% else %}
             <p>&zwnj;</p>
             {% endif %}
+            <p style="margin-top: -5px">
             {% if beatmap_entry.beatmap.mode == 0 %}
                 <img alt="osu" src="{% static "gamemode/osu.png" %}" width="20px" height="20px">
             {% elif beatmap_entry.beatmap.mode == 1 %}
@@ -30,29 +31,29 @@
 
             {% include "beatmap_collections/snippets/star_rating_color.html" %}
             {% if beatmap_entry.beatmap.approved == "4" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61); margin-top: -2px">LOVED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61);">LOVED</span>
             {% elif beatmap_entry.beatmap.approved == "3" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(106, 196, 254); color: rgb(51, 58, 61); margin-top: -2px">QUALIFIED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(106, 196, 254); color: rgb(51, 58, 61);">QUALIFIED</span>
             {% elif beatmap_entry.beatmap.approved == "2" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(210, 208, 85); color: rgb(51, 58, 61); margin-top: -2px">APPROVED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(210, 208, 85); color: rgb(51, 58, 61);">APPROVED</span>
             {% elif beatmap_entry.beatmap.approved == "1" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(185, 251, 98); color: rgb(51, 58, 61); margin-top: -2px">RANKED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(185, 251, 98); color: rgb(51, 58, 61);">RANKED</span>
             {% elif beatmap_entry.beatmap.approved == "0" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(252, 212, 96); color: rgb(51, 58, 61); margin-top: -2px">PENDING</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(252, 212, 96); color: rgb(51, 58, 61);">PENDING</span>
             {% elif beatmap_entry.beatmap.approved == "-1" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(245, 146, 93); color: rgb(51, 58, 61); margin-top: -2px">WIP</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(245, 146, 93); color: rgb(51, 58, 61);">WIP</span>
             {% elif beatmap_entry.beatmap.approved == "-2" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(0, 0, 0); color: rgb(83, 94, 101); margin-top: -2px">GRAVEYARD</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(0, 0, 0); color: rgb(83, 94, 101);">GRAVEYARD</span>
             {% endif %}
 
             </p>
-              <p class="card-text text-muted" style="margin-top: -5px"><small>mapped by <a href="https://osu.ppy.sh/users/{{ beatmap_entry.beatmap.creator_id }}" class="text-decoration-none spacing-hover-short">{{ beatmap_entry.beatmap.creator }}</a></small></p>
+              <p class="card-text text-muted beatmap-creator"><small>mapped by <a href="https://osu.ppy.sh/users/{{ beatmap_entry.beatmap.creator_id }}" class="text-decoration-none spacing-hover-short">{{ beatmap_entry.beatmap.creator }}</a></small></p>
           {% if beatmap_entry.comment != '' %}
-              <p class="card-text beatmap-comment" style="margin-top: -5px"><small>{{ beatmap_entry.comment }}</small></p>
+              <p class="card-text beatmap-comment"><small>{{ beatmap_entry.comment }}</small></p>
           {% else %}
-            <p class="card-text beatmap-comment" style="margin-top: -5px">&nbsp;</p>
+            <p class="card-text beatmap-comment">&nbsp;</p>
           {% endif %}
-              <p class="card-text text-muted" style="margin-top: -10px"><small>Recommend by <a href="{% url 'profile' beatmap_entry.author.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap_entry.author.profile.profile_picture.url }}" alt="{{ beatmap_entry.author.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap_entry.author.username }}</a></small></p>
+              <p class="card-text text-muted beatmap-author"><small>Recommend by <a href="{% url 'profile' beatmap_entry.author.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap_entry.author.profile.profile_picture.url }}" alt="{{ beatmap_entry.author.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap_entry.author.username }}</a></small></p>
           <p class="card-text"><a class="btn btn-success btn-sm hvr-sweep-to-right-success" href="{% url 'approve_beatmap' collection.id beatmap_entry.id %}" role="button" style="margin-top: -10px"><i class="fas fa-check color-white"></i> Approve</a> <a class="btn btn-danger btn-sm hvr-sweep-to-right-danger" href="{% url 'deny_beatmap' collection.id beatmap_entry.id %}" role="button" style="margin-top: -10px"><i class="fas fa-times color-white"></i> Deny</a></p>
           </div>
         </div>

--- a/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card_demo.html
+++ b/beatmap_collections/templates/beatmap_collections/snippets/beatmap_card_demo.html
@@ -19,12 +19,13 @@
         <div class="col-md-8 rounded-start" style="line-height: 0.3; background-image: url('https://assets.ppy.sh/beatmaps/{{ beatmap.beatmapset_id }}/covers/card.jpg'); background-size: cover; background-position: center;">
           <div class="card-body beatmap-card rounded-start rounded-3">
             <a href="{{ beatmap.url }}" class="text-decoration-none"><h4 class="card-title spacing-hover-short beatmap-title fw-bold">{{ beatmap.title }}</h4></a>
-            <p class="card-text" style="line-height: 0.8">by {{ beatmap.artist }}</p>
+            <p class="card-text beatmap-artist">by {{ beatmap.artist }}</p>
             {% if beatmap.source != "" %}
             <p class="card-text text-muted beatmap-source">{{ beatmap.source }}</p>
             {% else %}
             <p>&zwnj;</p>
             {% endif %}
+            <p style="margin-top: -5px">
             {% if beatmap.mode == "0" %}
                 <img alt="osu" src="{% static "gamemode/osu.png" %}" width="20px" height="20px">
             {% elif beatmap.mode == "1" %}
@@ -37,29 +38,29 @@
 
             {% include "beatmap_collections/snippets/star_rating_color_demo.html" %}
             {% if beatmap.approved == "4" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61); margin-top: -2px">LOVED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61);">LOVED</span>
             {% elif beatmap.approved == "3" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(106, 196, 254); color: rgb(51, 58, 61); margin-top: -2px">QUALIFIED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(106, 196, 254); color: rgb(51, 58, 61);">QUALIFIED</span>
             {% elif beatmap.approved == "2" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(210, 208, 85); color: rgb(51, 58, 61); margin-top: -2px">APPROVED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(210, 208, 85); color: rgb(51, 58, 61);">APPROVED</span>
             {% elif beatmap.approved == "1" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(185, 251, 98); color: rgb(51, 58, 61); margin-top: -2px">RANKED</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(185, 251, 98); color: rgb(51, 58, 61);">RANKED</span>
             {% elif beatmap.approved == "0" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(252, 212, 96); color: rgb(51, 58, 61); margin-top: -2px">PENDING</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(252, 212, 96); color: rgb(51, 58, 61);">PENDING</span>
             {% elif beatmap.approved == "-1" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(245, 146, 93); color: rgb(51, 58, 61); margin-top: -2px">WIP</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(245, 146, 93); color: rgb(51, 58, 61);">WIP</span>
             {% elif beatmap.approved == "-2" %}
-                <span class="badge rounded-pill bold-font" style="background-color: rgb(0, 0, 0); color: rgb(83, 94, 101); margin-top: -2px">GRAVEYARD</span>
+                <span class="badge rounded-pill bold-font" style="background-color: rgb(0, 0, 0); color: rgb(83, 94, 101);">GRAVEYARD</span>
             {% endif %}
 
             </p>
               <p class="card-text text-muted" style="margin-top: -5px"><small>mapped by <a href="https://osu.ppy.sh/users/{{ beatmap.creator_id }}" class="text-decoration-none spacing-hover-short">{{ beatmap.creator }}</a></small></p>
           {% if beatmap_entry.comment != '' %}
-              <p class="card-text beatmap-comment" style="margin-top: -5px"><small>{{ beatmap_entry.comment }}</small></p>
+              <p class="card-text beatmap-comment"><small>{{ beatmap_entry.comment }}</small></p>
           {% else %}
-            <p class="card-text beatmap-comment" style="margin-top: -5px">&nbsp;</p>
+            <p class="card-text beatmap-comment">&nbsp;</p>
           {% endif %}
-              <p class="card-text text-muted" style="margin-top: -10px"><small>Added by <a href="{% url 'profile' user.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ user.profile.profile_picture.url }}" alt="{{ user.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ user.username }}</a></small></p>
+              <p class="card-text text-muted beatmap-author"><small>Added by <a href="{% url 'profile' user.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ user.profile.profile_picture.url }}" alt="{{ user.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ user.username }}</a></small></p>
           <a class="btn btn-beattosetto btn-sm hvr-bounce-to-bottom" href="osu://b/{{ beatmap.beatmap_id }}" role="button" style="margin-top: -10px"><i class="fas fa-download color-white"></i> osu!direct</a>
           <button type="button" class="btn btn-beattosetto btn-sm hvr-bounce-to-bottom" data-bs-toggle="modal" data-bs-target="#modal{{ beatmap.beatmap_id }}" style="margin-top: -10px">
               <i class="fas fa-info-circle"></i> Beatmap Detail


### PR DESCRIPTION
Hi! There's two things in this PRs.

# Fix line layout is broken when beatmap source is too long

Close #163

I fix the problem on line layout when the beatmap source is longer than one line. It's occured from the normal beatmap card line height that is very thin (0.4). That's why I fix this by fix the line height of beatmap source.

| Before | After |
|----------|---------|
| ![image](https://user-images.githubusercontent.com/68165621/140660127-b60af12c-7159-41ff-a112-57cb842e7cd1.png) | ![image](https://user-images.githubusercontent.com/68165621/140660152-f4847d21-c0b8-4cce-924a-139c4b65982a.png) |

# Refactor some inline styling to CSS class

I got mention from @pontakornth that sometime frontend team is confused in beatmap card styling that I design and code it. That's why I refactor inline styling that can move from inline style in HTML to class and use CSS as a styling control.

The area that effect in refactoring:
- Normal beatmap card
- Demo beatmap card
- Beatmap card in approval page