### PR TITLE
Fix line bug in beatmap artist when the artist name is longer than one line

### DIFF
--- a/beatmap_collections/static/css/index.css
+++ b/beatmap_collections/static/css/index.css
@@ -262,7 +262,7 @@ a.dropdown-item {
 }
 
 .beatmap-artist {
-    line-height: 0.8;
+    line-height: normal;
 }
 
 .beatmap-source {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68165621/140685072-bef0512f-d572-414d-810f-75614fb5989d.png)

Hi, I found the bug when our bug hunter (@SainTurDaY27) add a beatmap. I fix it by just make the line height higher.