### PR TITLE
Fix API request has 404 error when no text on beatmap ID field

### DIFF
--- a/beatmap_collections/static/js/live_beatmap_card.js
+++ b/beatmap_collections/static/js/live_beatmap_card.js
@@ -1,6 +1,13 @@
 function RenderDemoCard(value) {
+    // If the value in form is blank, get an API call as the beatmap ID is 0
+    let api_url = '';
+    if (value === '') {
+        api_url = '/api/get_demo_card/0'
+    } else {
+        api_url = '/api/get_demo_card/' + value
+    }
     // Use ajax to get the rendered beatmap card
-    $.ajax({url: '/api/get_demo_card/' + value, success: function(result) {
+    $.ajax({url: api_url, success: function(result) {
         document.getElementById('beatmap-card').innerHTML = '<div id="demo-beatmap-card"></div>';
         $('#demo-beatmap-card').replaceWith(result);
         $('.mediPlayer').mediaPlayer();

--- a/beatmap_collections/static/js/live_beatmap_card.js
+++ b/beatmap_collections/static/js/live_beatmap_card.js
@@ -1,11 +1,6 @@
 function RenderDemoCard(value) {
     // If the value in form is blank, get an API call as the beatmap ID is 0
-    let api_url = '';
-    if (value === '') {
-        api_url = '/api/get_demo_card/0'
-    } else {
-        api_url = '/api/get_demo_card/' + value
-    }
+    let api_url = `/api/get_demo_card/${value || 0}`;
     // Use ajax to get the rendered beatmap card
     $.ajax({url: api_url, success: function(result) {
         document.getElementById('beatmap-card').innerHTML = '<div id="demo-beatmap-card"></div>';

--- a/beatmap_collections/views_api.py
+++ b/beatmap_collections/views_api.py
@@ -7,6 +7,16 @@ from .functions import get_beatmap_detail
 @login_required
 def live_beatmap_card(request, beatmap_id):
     """Return an HTTP of the beatmap card"""
+    # We fix the JavaScript in add beatmap page that if the value in form is blank, return beatmap ID as 0
+    if beatmap_id == 0:
+        response = """
+        <div data-aos="fade-up" data-aos-duration="600" data-aos-once="true">
+            <div id="demo-beatmap-card"></div>
+                <img src="/static/img/how-to-get-beatmap-id.png" alt="How to get a beatmap ID" style="max-width: 100%;">
+            <p class="text-muted">ID of your recommend beatmap that you want to add.</p>
+        </div>
+        """
+        return HttpResponse(response, content_type='text/html')
     beatmap_detail = get_beatmap_detail(beatmap_id)
     if beatmap_detail:
         beatmap_card = render(request, 'beatmap_collections/snippets/beatmap_card_demo.html', {'beatmap': beatmap_detail})


### PR DESCRIPTION
Close #133 

I fix this by make the JS side request the API with beatmap ID as 0. When request as this value the API view will return the HTTPResponse as the picture like you open the add beatmap page for the first time.