### PR TITLE
Fix duplicate username change lead to 500 error

### DIFF
--- a/users/templates/users/settings.html
+++ b/users/templates/users/settings.html
@@ -78,7 +78,7 @@
             <div class="mb-3 row">
                 <label for="id_email" class="col-form-label col-lg-3">{{ user_form.email.label_tag }}</label>
                 <div class="col-lg-9">
-                    <input type="email" id="id_email" name="email" class="form-control" placeholder="Your Email" value="{{ user_form.email.value }}" required>
+                    <input type="email" id="id_email" name="email" class="form-control" placeholder="Your Email" value="{{ user_form.email.value }}">
                     <p class="form-error">{{ user_form.email.errors }}</p>
                     <p class="text-muted">Your Email like yourgarden@suringarden.com</p>
                 </div>

--- a/users/views.py
+++ b/users/views.py
@@ -30,7 +30,7 @@ def settings(request):
     if request.method == 'POST':
         profile_form = ProfileUpdateForm(request.POST, request.FILES, instance=request.user.profile)
         user_form = UserUpdateForm(request.POST, instance=request.user)
-        if profile_form.is_valid():
+        if profile_form.is_valid() and user_form.is_valid():
             profile_form.save()
             user_form.save()
             messages.success(request, 'Update your cool profile successfully!')


### PR DESCRIPTION
Close #200 

This is regress from the setting view is not check that the `user_form` is valid and I see that the email is needed before user can change anything in the settings page so I fix this too.