### PR TITLE
Fix text wrap is not actually wrap and line breaking on comment

### DIFF
--- a/beatmap_collections/static/css/index.css
+++ b/beatmap_collections/static/css/index.css
@@ -46,7 +46,6 @@ a:hover {
 
 h1 {
     /* I want header 1 to be the only header that is bold */
-    font-family: "Comfortaa", cursive;
     font-weight: bold;
 }
 

--- a/beatmap_collections/templates/beatmap_collections/collection_page.html
+++ b/beatmap_collections/templates/beatmap_collections/collection_page.html
@@ -143,7 +143,7 @@
         <div class="fieldWrapper">
             <h2 data-aos="fade-up" data-aos-duration="600" data-aos-once="true">Add Comment</h2>
             <p></p>
-            <textarea name="comment" cols="40" rows="5" class="form-control" id="id_comment" maxlength="250" placeholder="Post a lovely comment to collection here." data-aos="fade-up" data-aos-duration="500" data-aos-once="true"></textarea>
+            <input type="text" id="id_comment" name="comment" class="form-control" placeholder="Post a lovely comment to collection here." data-aos="fade-up" data-aos-duration="500" data-aos-once="true">
             <p class="form-error" data-aos="fade-up" data-aos-duration="600" data-aos-once="true">{{ form.comment.errors }}</p>
         </div>
         <p></p>
@@ -162,7 +162,7 @@
             </p>
         </a>
         <p class="text-muted">Commented at {{ comment_object.create_date | date:"F j, Y h:i A" }}</p>
-        <p>{{ comment_object.detail }}</p>
+        <p style="word-wrap: break-word;">{{ comment_object.detail }}</p>
         <div class="row">
             {% if user == comment_object.user %}
             <div class="col-sm-2">

--- a/beatmap_collections/templates/beatmap_collections/edit_comment.html
+++ b/beatmap_collections/templates/beatmap_collections/edit_comment.html
@@ -42,7 +42,7 @@
         {% csrf_token %}
         <div class="fieldWrapper">
             <div class="mb-3 col-sm-12">
-                <textarea name="detail" cols="40" rows="5" class="form-control" id="id_detail" maxlength="250" placeholder="Post a lovely comment to collection here." required>{{ form.detail.value }}</textarea>
+                <input type="text" id="id_comment" name="comment" class="form-control" placeholder="Post a lovely comment to collection here." data-aos="fade-up" data-aos-duration="500" data-aos-once="true" required value="{{ form.detail.value }}">
                 <p class="form-error">{{ form.detail.errors }}</p>
             </div>
         </div>


### PR DESCRIPTION
Sometimes the line break in comment box is not work and when comment is too long it will be go overflow over the 'div' so I change the text input too 'input' instead of 'textbox' and fix the line wrapping style too.