### PR TITLE
Add more reliability on some case

### DIFF
--- a/beatmap_collections/views.py
+++ b/beatmap_collections/views.py
@@ -363,7 +363,7 @@ def edit_beatmap_comment(request, collection_id, beatmap_entry_id):
 def edit_comment(request, collection_id, comment_id):
     """View for edit comment form"""
     collection = get_object_or_404(Collection, id=collection_id)
-    comment = get_object_or_404(Comment, id=comment_id)
+    comment = get_object_or_404(Comment, id=comment_id, collection=collection)
     if request.user != comment.user:
         messages.error(request, "That's your comment? NO!")
         return redirect('collection', collection_id=collection_id)

--- a/beatmap_collections/views.py
+++ b/beatmap_collections/views.py
@@ -335,7 +335,7 @@ def delete_comment(request, collection_id, comment_id):
 def edit_beatmap_comment(request, collection_id, beatmap_entry_id):
     """View for edit beatmap comment in BeatmapEntry"""
     collection = get_object_or_404(Collection, id=collection_id)
-    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id)
+    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id, collection=collection)
     if request.user != collection.author:
         messages.error(request, 'BAKA! You are not the author of this collection!')
         return redirect('collection', collection_id=collection_id)

--- a/beatmap_collections/views.py
+++ b/beatmap_collections/views.py
@@ -317,7 +317,7 @@ def delete_collection(request, collection_id):
 def delete_comment(request, collection_id, comment_id):
     """Delete comment if the staff or comment owner want to delete."""
     collection = get_object_or_404(Collection, id=collection_id)
-    comment = get_object_or_404(Comment, id=comment_id)
+    comment = get_object_or_404(Comment, id=comment_id, collection=collection)
     if not request.user.is_authenticated:
         messages.error(request, "Stop there! How dare you delete a comment without logging in?")
         return redirect('collection', collection_id=collection.id)

--- a/beatmap_collections/views.py
+++ b/beatmap_collections/views.py
@@ -197,7 +197,7 @@ def beatmap_approval(request, collection_id):
 def approve_beatmap(request, collection_id, beatmap_entry_id):
     """View for approve BeatmapEntry to the collection by changing the owner_approved value to True"""
     collection = get_object_or_404(Collection, id=collection_id)
-    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id)
+    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id, collection=collection)
     if request.user != collection.author:
         messages.error(request, 'Hehehehe No! Stop there!')
         return redirect('collection', collection_id=collection_id)
@@ -218,7 +218,7 @@ def approve_beatmap(request, collection_id, beatmap_entry_id):
 def deny_beatmap(request, collection_id, beatmap_entry_id):
     """View for deny BeatmapEntry to the collection by deleting the BeatmapEntry object"""
     collection = get_object_or_404(Collection, id=collection_id)
-    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id)
+    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id, collection=collection)
     if request.user != collection.author:
         messages.error(request, 'Hehehehe No! Stop there!')
         return redirect('collection', collection_id=collection_id)
@@ -234,7 +234,7 @@ def deny_beatmap(request, collection_id, beatmap_entry_id):
 def delete_beatmap(request, collection_id, beatmap_entry_id):
     """View for delete beatmap entry"""
     collection = get_object_or_404(Collection, id=collection_id)
-    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id)
+    beatmap_entry = get_object_or_404(BeatmapEntry, id=beatmap_entry_id, collection=collection)
     if request.user != collection.author:
         messages.error(request, "Hey! That's nonsense")
         return redirect('collection', collection_id=collection_id)


### PR DESCRIPTION
I just add the reliability that sometime users or staff can delete or edit some objects cross-collection.

For example:
I want to delete my comment ID `45` in collection `69` but I am lazy to go there so I just get the link to delete the comment `23` in collection `78` .

https://beatsets.info/collections/78/delete/comment/23

And change the link too:

https://beatsets.info/collections/78/delete/comment/45

And it can delete.

So I fix it in all views function that this can happen by add more verification on that object by check its collection that it's binding too.